### PR TITLE
Bugfix of macau.pyx

### DIFF
--- a/python/macau/macau.pyx
+++ b/python/macau/macau.pyx
@@ -7,6 +7,7 @@ import timeit
 import numbers
 import pandas as pd
 import signal
+import sys
 
 class MacauResult(object):
   def __init__(self):
@@ -356,7 +357,10 @@ def macau(Y,
         if type(save_prefix) != str:
             raise ValueError("Parameter 'save_prefix' has to be a string (str) or None.")
         macau.setSaveModel(1)
-        macau.setSavePrefix(save_prefix)
+        if sys.version_info[0] >= 3:
+            macau.setSavePrefix(save_prefix.encode())
+        else:
+            macau.setSavePrefix(save_prefix)
 
     macau.run()
     ## restoring Python default signal handler


### PR DESCRIPTION
Hi Jaak.
When I run macau with "save_prefix" option in Python 3.5.4, I got an error like the following.
Traceback (most recent call last):
  File "./run_macau.py", line 29, in <module>
    save_prefix = 'mymodel')
  File "python/macau/macau.pyx", line 359, in macau.macau.macau (python/macau/macau.cpp:11838)
  File "stringsource", line 15, in string.from_py.__pyx_convert_string_from_py_std__in_string (python/macau/macau.cpp:14566)
TypeError: expected bytes, str found

Therefore, I made a bit change in macau.pyx so as to be compatible with Python3.
Could you please confirm it?